### PR TITLE
WIP: [CI] 1) Revert undesired change, 2) replace adhoc set of scripts with industrial_ci :)

### DIFF
--- a/.install_dependency.sh
+++ b/.install_dependency.sh
@@ -8,7 +8,8 @@
 
 COMMAND="deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main"
 echo $COMMAND | tee /etc/apt/sources.list.d/realsense-public.list
-add-apt-repository "$COMMAND"
 apt-get update -qq
+apt-get install software-properties-common -y  # On Ubuntu Bionic, add-apt-repository is not installed by default. 
+add-apt-repository "$COMMAND"
 apt-get install librealsense2-dkms --allow-unauthenticated -y 
 apt-get install librealsense2-dev --allow-unauthenticated -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 dist: xenial
 
-  # - git clone -v --progress https://github.com/doronhi/realsense.git  # This is Done automatically by TravisCI
 before_install:
   - sudo ./.install_dependency.sh
   
@@ -39,11 +38,11 @@ install:
   # Run test:
 script:
   - python src/realsense/realsense2_camera/scripts/rs2_test.py --all
-  
  
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
     - $HOME/.gradle/caches/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,15 @@
 sudo: required
 dist: xenial
+services:
+  - docker
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    recipients:
+      - isaac.saito@plusonerobotics.com
 
-before_install:
-  - sudo ./.install_dependency.sh
-  
-install:
-  # install ROS:
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-  - sudo apt-get update -qq
-  - sudo apt-get install ros-kinetic-ros-base -y
-  - sudo rosdep init
-  - rosdep update
-  - echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
-  - sudo apt-get install ros-kinetic-cv-bridge -y
-  - sudo apt-get install ros-kinetic-image-transport
-  - sudo apt-get install ros-kinetic-tf -y
-  - sudo apt-get install ros-kinetic-diagnostic-updater -y
-  - source ~/.bashrc
-  - mkdir -p ~/catkin_ws/src/realsense
-    
-  # install realsense2-camera
-  - mv * ~/catkin_ws/src/realsense/     # This leaves behind .git, .gitignore and .travis.yml but no matter.
-  - cd ~/catkin_ws/src/
-  - catkin_init_workspace 
-  - cd ..
-  - catkin_make clean
-  - catkin_make -DCATKIN_ENABLE_TESTING=False -DCMAKE_BUILD_TYPE=Release
-  - catkin_make install
-  - echo "source ~/catkin_ws/devel/setup.bash" >> ~/.bashrc
-  - source ~/.bashrc
-  
-    # download data:
-  - bag_filename="http://realsense-hw-public.s3.amazonaws.com/rs-tests/TestData/outdoors.bag";
-  - wget $bag_filename -P "records/"
-    
-  # Run test:
-script:
-  - python src/realsense/realsense2_camera/scripts/rs2_test.py --all
- 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -48,3 +19,18 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
+
+env:
+  global:
+    - AFTER_SCRIPT="echo 'Run custom test'; python src/realsense/realsense2_camera/scripts/rs2_test.py --all"
+    - BEFORE_SCRIPT="./.install_dependency.sh; echo 'download data' && bag_filename='http://realsense-hw-public.s3.amazonaws.com/rs-tests/TestData/outdoors.bag' && wget $bag_filename -P 'records/'"
+
+  matrix:
+    - ROS_DISTRO="kinetic"   ROS_REPO=ros
+    - ROS_DISTRO="kinetic"   PRERELEASE=true
+    - ROS_DISTRO="melodic"   ROS_REPO=ros
+    - ROS_DISTRO="melodic"   PRERELEASE=true
+install:
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci
+script:
+  - .industrial_ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,7 @@ dist: xenial
 
   # - git clone -v --progress https://github.com/doronhi/realsense.git  # This is Done automatically by TravisCI
 before_install:
-  - echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
-  # - sudo apt-key adv --keyserver keys.gnupg.net --recv-key C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keys.gnupg.net:80 --recv-key C8B3A55A6F3EFCDE
-  - sudo add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main"
-  - sudo apt-get update -qq
-  - sudo apt-get install librealsense2-dkms --allow-unauthenticated -y 
-  - sudo apt-get install librealsense2-dev --allow-unauthenticated -y
+  - sudo ./.install_dependency.sh
   
 install:
   # install ROS:


### PR DESCRIPTION
# What's the change

For more close review, see commit-by-commit.

- I merged a PR that included an undesired change that reverted a good change https://github.com/plusone-robotics/realsense/pull/16#discussion_r257416100. In this PR that good change is reverted back.
- Replaces most of the commands in the Travis config file with industrial_ci.
  - .travis.yml on this repo consists of adhoc commands with fixed values. `industrial_ci` is tested by hundreds of users and can give flexibility for future change.

# Review items
- [ ] CI passes.
  - Due to flaky tests (kindf of reported at the upstream https://github.com/intel-ros/realsense/issues/619#issuecomment-464238122 although that's not the right approach to fix an issue), test section likely fails but Travis CI will unlikely report it as a failure.
