### PR TITLE
Node should stay alive even if realsense disconnects

### DIFF
--- a/.install_dependency.sh
+++ b/.install_dependency.sh
@@ -5,9 +5,8 @@
 # This is a convenience script (hopefully temporary) to install dependency of https://github.com/intel-ros/realsense.
 # Codes taken from https://github.com/intel-ros/realsense/blob/c5ea27245967e0938f7d10384f4b7279e01000b4/.travis.yml
 
-COMMAND="deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main"
-echo $COMMAND | tee /etc/apt/sources.list.d/realsense-public.list
-add-apt-repository "$COMMAND"
+echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
+add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main"
 apt-get update -qq
 apt-get install librealsense2-dkms --allow-unauthenticated -y 
 apt-get install librealsense2-dev --allow-unauthenticated -y

--- a/.install_dependency.sh
+++ b/.install_dependency.sh
@@ -5,8 +5,9 @@
 # This is a convenience script (hopefully temporary) to install dependency of https://github.com/intel-ros/realsense.
 # Codes taken from https://github.com/intel-ros/realsense/blob/c5ea27245967e0938f7d10384f4b7279e01000b4/.travis.yml
 
-echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
-add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main"
+COMMAND="deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main"
+echo $COMMAND | tee /etc/apt/sources.list.d/realsense-public.list
+add-apt-repository "$COMMAND"
 apt-get update -qq
 apt-get install librealsense2-dkms --allow-unauthenticated -y 
 apt-get install librealsense2-dev --allow-unauthenticated -y

--- a/.install_dependency.sh
+++ b/.install_dependency.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Copyright (c) 2018, PlusOne Robotics Inc. All rights reserved.
+
+# This is a convenience script (hopefully temporary) to install dependency of https://github.com/intel-ros/realsense.
+# Codes taken from https://github.com/intel-ros/realsense/blob/c5ea27245967e0938f7d10384f4b7279e01000b4/.travis.yml
+
+echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
+add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main"
+apt-get update -qq
+apt-get install librealsense2-dkms --allow-unauthenticated -y 
+apt-get install librealsense2-dev --allow-unauthenticated -y

--- a/.install_dependency.sh
+++ b/.install_dependency.sh
@@ -4,9 +4,11 @@
 
 # This is a convenience script (hopefully temporary) to install dependency of https://github.com/intel-ros/realsense.
 # Codes taken from https://github.com/intel-ros/realsense/blob/c5ea27245967e0938f7d10384f4b7279e01000b4/.travis.yml
+# When used on CI sudo is not usually needed but it is most likely needed when used on your local computer.
 
-echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
-add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main"
+COMMAND="deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main"
+echo $COMMAND | tee /etc/apt/sources.list.d/realsense-public.list
+add-apt-repository "$COMMAND"
 apt-get update -qq
 apt-get install librealsense2-dkms --allow-unauthenticated -y 
 apt-get install librealsense2-dev --allow-unauthenticated -y

--- a/.install_dependency.sh
+++ b/.install_dependency.sh
@@ -5,7 +5,7 @@
 # This is a convenience script (hopefully temporary) to install dependency of https://github.com/intel-ros/realsense.
 # Codes taken from https://github.com/intel-ros/realsense/blob/c5ea27245967e0938f7d10384f4b7279e01000b4/.travis.yml
 
-echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
+echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
 add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main"
 apt-get update -qq
 apt-get install librealsense2-dkms --allow-unauthenticated -y 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ dist: xenial
 
   # - git clone -v --progress https://github.com/doronhi/realsense.git  # This is Done automatically by TravisCI
 before_install:
-  - ./.install_dependency.sh
+  - echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
+  # - sudo apt-key adv --keyserver keys.gnupg.net --recv-key C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keys.gnupg.net:80 --recv-key C8B3A55A6F3EFCDE
+  - sudo add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main"
+  - sudo apt-get update -qq
+  - sudo apt-get install librealsense2-dkms --allow-unauthenticated -y 
+  - sudo apt-get install librealsense2-dev --allow-unauthenticated -y
   
 install:
   # install ROS:
@@ -48,4 +53,4 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-    - $HOME/.android/build-cache
+- $HOME/.android/build-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,7 @@ dist: xenial
 
   # - git clone -v --progress https://github.com/doronhi/realsense.git  # This is Done automatically by TravisCI
 before_install:
-  - echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
-  # - sudo apt-key adv --keyserver keys.gnupg.net --recv-key C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keys.gnupg.net:80 --recv-key C8B3A55A6F3EFCDE
-  - sudo add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main"
-  - sudo apt-get update -qq
-  - sudo apt-get install librealsense2-dkms --allow-unauthenticated -y 
-  - sudo apt-get install librealsense2-dev --allow-unauthenticated -y
+  - ./.install_dependency.sh
   
 install:
   # install ROS:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,7 @@ dist: xenial
 
   # - git clone -v --progress https://github.com/doronhi/realsense.git  # This is Done automatically by TravisCI
 before_install:
-  - echo 'deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main' || sudo tee /etc/apt/sources.list.d/realsense-public.list
-  # - sudo apt-key adv --keyserver keys.gnupg.net --recv-key C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keys.gnupg.net:80 --recv-key C8B3A55A6F3EFCDE
-  - sudo add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main"
-  - sudo apt-get update -qq
-  - sudo apt-get install librealsense2-dkms --allow-unauthenticated -y 
-  - sudo apt-get install librealsense2-dev --allow-unauthenticated -y
+  - sudo ./.install_dependency.sh
   
 install:
   # install ROS:

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -81,6 +81,8 @@ namespace realsense2_camera
         virtual void onInit() override;
         void tryGetLogSeverity(rs2_log_severity& severity) const;
 
+        void setupRealsenseNode(rs2::device&, ros::NodeHandle&, ros::NodeHandle&, std::string&, std::unique_ptr<InterfaceRealSenseNode>&);
+
         std::unique_ptr<InterfaceRealSenseNode> _realSenseNode;
         rs2::device _device;
         rs2::context _ctx;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1253,10 +1253,10 @@ void BaseRealSenseNode::publishITRTopic(sensor_msgs::PointCloud2& msg_pointcloud
                 *iter_y = depth_point[1];
                 *iter_z = depth_point[2];
 
-                auto i = static_cast<int>(depth_pixel[0] * width_ratio);
-                auto j = static_cast<int>(depth_pixel[1] * height_ratio);
+                auto i = static_cast<int>(depth_pixel[0] * 2);
+                auto j = static_cast<int>(depth_pixel[1] * 2);
 
-                auto offset = i * 3 + j * depth_intrinsics.width * 3;
+                auto offset = i * 3 + j * infrargb_intrinsics.width * 3;
                 *iter_r = static_cast<uint8_t>(color_data[offset]);
                 *iter_g = static_cast<uint8_t>(color_data[offset + 1]);
                 *iter_b = static_cast<uint8_t>(color_data[offset + 2]);

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -691,7 +691,7 @@ void BaseRealSenseNode::setupStreams()
                                 _image[DEPTH].data = (uint8_t*)depth_frame.get_data();
                             }
 
-                            if (_enable_filter && is_frame_arrived.at(COLOR))
+                            if (_enable_filter && is_frame_arrived.at(INFRARGB))
                             {
                                 publishFrame(f, t,
                                              sip,
@@ -1171,7 +1171,7 @@ void BaseRealSenseNode::publishRgbToDepthPCTopic(const ros::Time& t, const std::
 {
     try
     {
-        if (!is_frame_arrived.at(COLOR) || !is_frame_arrived.at(DEPTH))
+        if (!is_frame_arrived.at(INFRARGB) || !is_frame_arrived.at(DEPTH))
         {
             ROS_DEBUG("Skipping publish PC topic! Color or Depth frame didn't arrive.");
             return;
@@ -1214,11 +1214,13 @@ void BaseRealSenseNode::publishRgbToDepthPCTopic(const ros::Time& t, const std::
 
 void BaseRealSenseNode::publishITRTopic(sensor_msgs::PointCloud2& msg_pointcloud, bool colorized_pointcloud)
 {
-    auto& depth2color_extrinsics = _depth_to_other_extrinsics[COLOR];
-    auto color_intrinsics = _stream_intrinsics[COLOR];
+    auto infrargb_intrinsics = _stream_intrinsics[INFRARGB];
     auto depth_intrinsics = _stream_intrinsics[DEPTH];
     auto image_depth16 = reinterpret_cast<const uint16_t*>(_image[DEPTH].data);
-    unsigned char* color_data = _image[COLOR].data;
+    auto width_ratio = static_cast<float>(infrargb_intrinsics.width) / static_cast<float>(depth_intrinsics.width);
+    auto height_ratio = static_cast<float>(infrargb_intrinsics.height) / static_cast<float>(depth_intrinsics.height);
+
+    unsigned char* color_data = _image[INFRARGB].data;
     const float MIN_DEPTH_THRESHOLD = 0.f;
     const float MAX_DEPTH_THRESHOLD = 5.f;
     float depth_point[3], scaled_depth;
@@ -1240,7 +1242,6 @@ void BaseRealSenseNode::publishITRTopic(sensor_msgs::PointCloud2& msg_pointcloud
                 scaled_depth = static_cast<float>(*image_depth16) * _depth_scale_meters;
                 float depth_pixel[2] = {static_cast<float>(x), static_cast<float>(y)};
                 rs2_deproject_pixel_to_point(depth_point, &depth_intrinsics, depth_pixel, scaled_depth);
-
                 if (depth_point[2] <= MIN_DEPTH_THRESHOLD || depth_point[2] > MAX_DEPTH_THRESHOLD)
                 {
                     depth_point[0] = MIN_DEPTH_THRESHOLD;
@@ -1252,30 +1253,13 @@ void BaseRealSenseNode::publishITRTopic(sensor_msgs::PointCloud2& msg_pointcloud
                 *iter_y = depth_point[1];
                 *iter_z = depth_point[2];
 
-                float color_point[3], color_pixel[2];
+                auto i = static_cast<int>(depth_pixel[0] * width_ratio);
+                auto j = static_cast<int>(depth_pixel[1] * height_ratio);
 
-                rs2_transform_point_to_point(color_point, &depth2color_extrinsics, depth_point);
-                rs2_project_point_to_pixel(color_pixel, &color_intrinsics, color_point);
-
-                if (color_pixel[1] < MIN_DEPTH_THRESHOLD || color_pixel[1] > color_intrinsics.height
-                    || color_pixel[0] < MIN_DEPTH_THRESHOLD || color_pixel[0] > color_intrinsics.width)
-                {
-                    // For out of bounds color data, default to a shade of blue in order to visually distinguish holes.
-                    // This color value is same as the librealsense out of bounds color value.
-                    *iter_r = static_cast<uint8_t>(96);
-                    *iter_g = static_cast<uint8_t>(157);
-                    *iter_b = static_cast<uint8_t>(198);
-                }
-                else
-                {
-                    auto i = static_cast<int>(color_pixel[0]);
-                    auto j = static_cast<int>(color_pixel[1]);
-
-                    auto offset = i * 3 + j * color_intrinsics.width * 3;
-                    *iter_r = static_cast<uint8_t>(color_data[offset]);
-                    *iter_g = static_cast<uint8_t>(color_data[offset + 1]);
-                    *iter_b = static_cast<uint8_t>(color_data[offset + 2]);
-                }
+                auto offset = i * 3 + j * depth_intrinsics.width * 3;
+                *iter_r = static_cast<uint8_t>(color_data[offset]);
+                *iter_g = static_cast<uint8_t>(color_data[offset + 1]);
+                *iter_b = static_cast<uint8_t>(color_data[offset + 2]);
 
                 ++image_depth16;
                 ++iter_x; ++iter_y; ++iter_z;

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -70,6 +70,59 @@ rs2::device RealSenseNodeFactory::getDevice(std::string& serial_no)
     return retDev;
 }
 
+void RealSenseNodeFactory::setupRealsenseNode(rs2::device& device, ros::NodeHandle& nh, ros::NodeHandle& privateNh, std::string& serial_no, std::unique_ptr<InterfaceRealSenseNode>& realSenseNode)
+{
+	auto pid_str = device.get_info(RS2_CAMERA_INFO_PRODUCT_ID);
+	uint16_t pid;
+	std::stringstream ss;
+	ss << std::hex << pid_str;
+	ss >> pid;
+	switch(pid)
+	{
+	    case SR300_PID:
+	        realSenseNode = std::unique_ptr<SR300Node>(new SR300Node(nh, privateNh, device, serial_no));
+	        break;
+	    case RS400_PID:
+	        realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, device, serial_no));
+	        break;
+	    case RS405_PID:
+	        realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, device, serial_no));
+	        break;
+	    case RS410_PID:
+	    case RS460_PID:
+	        realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, device, serial_no));
+	        break;
+	    case RS415_PID:
+	        realSenseNode = std::unique_ptr<RS415Node>(new RS415Node(nh, privateNh, device, serial_no));
+	        break;
+	    case RS420_PID:
+	        realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, device, serial_no));
+	        break;
+	    case RS420_MM_PID:
+	        realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, device, serial_no));
+	        break;
+	    case RS430_PID:
+	        realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, device, serial_no));
+	        break;
+	    case RS430_MM_PID:
+	        realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
+	        break;
+	    case RS430_MM_RGB_PID:
+	        realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, device, serial_no));
+	        break;
+	    case RS435_RGB_PID:
+	        realSenseNode = std::unique_ptr<RS435Node>(new RS435Node(nh, privateNh, device, serial_no));
+	        break;
+	    case RS_USB2_PID:
+	        realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, device, serial_no));
+	        break;
+	    default:
+	        ROS_FATAL_STREAM("Unsupported device!" << " Product ID: 0x" << pid_str);
+	        ros::shutdown();
+	        exit(1);
+	}
+}
+
 void RealSenseNodeFactory::onInit()
 {
     try{
@@ -148,55 +201,7 @@ void RealSenseNodeFactory::onInit()
                     auto nh = getNodeHandle();
                     auto privateNh = getPrivateNodeHandle();
                     _device = retDev;
-                    auto pid_str = _device.get_info(RS2_CAMERA_INFO_PRODUCT_ID);
-                    uint16_t pid;
-                    std::stringstream ss;
-                    ss << std::hex << pid_str;
-                    ss >> pid;
-                    switch(pid)
-                    {
-                        case SR300_PID:
-                            _realSenseNode = std::unique_ptr<SR300Node>(new SR300Node(nh, privateNh, _device, serial_no));
-                            break;
-                        case RS400_PID:
-                            _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                            break;
-                        case RS405_PID:
-                            _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                            break;
-                        case RS410_PID:
-                        case RS460_PID:
-                            _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                            break;
-                        case RS415_PID:
-                            _realSenseNode = std::unique_ptr<RS415Node>(new RS415Node(nh, privateNh, _device, serial_no));
-                            break;
-                        case RS420_PID:
-                            _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                            break;
-                        case RS420_MM_PID:
-                            _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                            break;
-                        case RS430_PID:
-                            _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                            break;
-                        case RS430_MM_PID:
-                            _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                            break;
-                        case RS430_MM_RGB_PID:
-                            _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                            break;
-                        case RS435_RGB_PID:
-                            _realSenseNode = std::unique_ptr<RS435Node>(new RS435Node(nh, privateNh, _device, serial_no));
-                            break;
-                        case RS_USB2_PID:
-                            _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                            break;
-                        default:
-                            ROS_FATAL_STREAM("Unsupported device!" << " Product ID: 0x" << pid_str);
-                            ros::shutdown();
-                            exit(1);
-                    }
+                    setupRealsenseNode(_device, nh, privateNh, serial_no, _realSenseNode);
                    _device = retDev;
                     assert(_realSenseNode);
                     _realSenseNode->publishTopics();
@@ -206,55 +211,7 @@ void RealSenseNodeFactory::onInit()
                     });
 
             // TODO
-            auto pid_str = _device.get_info(RS2_CAMERA_INFO_PRODUCT_ID);
-            uint16_t pid;
-            std::stringstream ss;
-            ss << std::hex << pid_str;
-            ss >> pid;
-            switch(pid)
-            {
-                case SR300_PID:
-                    _realSenseNode = std::unique_ptr<SR300Node>(new SR300Node(nh, privateNh, _device, serial_no));
-                    break;
-                case RS400_PID:
-                    _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                    break;
-                case RS405_PID:
-                    _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                    break;
-                case RS410_PID:
-                case RS460_PID:
-                    _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                    break;
-                case RS415_PID:
-                    _realSenseNode = std::unique_ptr<RS415Node>(new RS415Node(nh, privateNh, _device, serial_no));
-                    break;
-                case RS420_PID:
-                    _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                    break;
-                case RS420_MM_PID:
-                    _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                    break;
-                case RS430_PID:
-                    _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                    break;
-                case RS430_MM_PID:
-                    _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                    break;
-                case RS430_MM_RGB_PID:
-                    _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                    break;
-                case RS435_RGB_PID:
-                    _realSenseNode = std::unique_ptr<RS435Node>(new RS435Node(nh, privateNh, _device, serial_no));
-                    break;
-                case RS_USB2_PID:
-                    _realSenseNode = std::unique_ptr<BaseD400Node>(new BaseD400Node(nh, privateNh, _device, serial_no));
-                    break;
-                default:
-                    ROS_FATAL_STREAM("Unsupported device!" << " Product ID: 0x" << pid_str);
-                    ros::shutdown();
-                    exit(1);
-            }
+            setupRealsenseNode(_device, nh, privateNh, serial_no, _realSenseNode);
         }
         assert(_realSenseNode);        _realSenseNode->publishTopics();
         _realSenseNode->registerDynamicReconfigCb();


### PR DESCRIPTION
Node should stay alive even if realsense disconnects. The node will continually look for a new realsense if the current realsense disconnects.

The pull request depends on https://github.com/plusone-robotics/realsense/pull/16/

The original MR for this is here https://github.com/plusone-robotics/realsense/pull/17

# Review items
- [x] Blocked by https://github.com/plusone-robotics/realsense/pull/19 -> Not needed https://github.com/plusone-robotics/realsense/pull/17#issuecomment-464346965
- [x] Verify w/hardware 
- [x] Rebase to the origin to remove #16 from the change in this PR.
- [x] CI passes.
  - Due to flaky tests (kindf of reported at the upstream https://github.com/intel-ros/realsense/issues/619#issuecomment-464238122 although that's not the right approach to fix an issue), test section likely fails but Travis CI will unlikely report it as a failure.