### PR TITLE
add decimation filter at the front of the filter list, before the start of disparity filter

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -870,6 +870,7 @@ void BaseRealSenseNode::setupFilters()
     boost::split(filters_str, _filters_str, [](char c){return c == ',';});
     bool use_disparity_filter(false);
     bool use_colorizer_filter(false);
+    bool use_decimation_filter(false);
     for (std::vector<std::string>::const_iterator s_iter=filters_str.begin(); s_iter!=filters_str.end(); s_iter++)
     {
         if ((*s_iter) == "colorizer")
@@ -897,8 +898,7 @@ void BaseRealSenseNode::setupFilters()
         }
         else if ((*s_iter) == "decimation")
         {
-            ROS_INFO("Add Filter: decimation");
-            _filters.push_back(NamedFilter("decimation", std::make_shared<rs2::decimation_filter>()));
+             use_decimation_filter = true;
         }
         else if ((*s_iter) == "pointcloud")
         {
@@ -916,6 +916,11 @@ void BaseRealSenseNode::setupFilters()
         _filters.insert(_filters.begin(), NamedFilter("disparity_start", std::make_shared<rs2::disparity_transform>()));
         _filters.push_back(NamedFilter("disparity_end", std::make_shared<rs2::disparity_transform>(false)));
         ROS_INFO("Done Add Filter: disparity");
+    }
+    if (use_decimation_filter)
+    {
+        ROS_INFO("Add Filter: decimation");
+        _filters.insert(_filters.begin(),NamedFilter("decimation", std::make_shared<rs2::decimation_filter>()));
     }
     if (use_colorizer_filter)
     {


### PR DESCRIPTION
Issue: decimation filter not working when using along with disparity filter
Linked to issue https://github.com/intel-ros/realsense/issues/501
For description on the issue please refer https://github.com/intel-ros/realsense/issues/501#issuecomment-484363443

The fix:
Avoid adding the decimation filter (if enabled by the user) in the for loop, instead add it to the front of the _filters vector, after the other filters (especially the disparity) have been applied (in the case of disparity both started and ended)