### PR TITLE
Support for topic monitoring and cleanly shutting down or resetting driver without killing nodelet manager.

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -101,7 +101,7 @@ namespace realsense2_camera
         void toggleSensors(bool enabled);
         virtual void publishTopics() override;
         virtual void registerDynamicReconfigCb(ros::NodeHandle& nh) override;
-        virtual ~BaseRealSenseNode() {}
+        virtual ~BaseRealSenseNode();
 
     public:
         enum imu_sync_method{NONE, COPY, LINEAR_INTERPOLATION};

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -22,6 +22,7 @@
 #include <eigen3/Eigen/Geometry>
 #include <fstream>
 #include <thread>
+#include <std_srvs/Empty.h>
 
 namespace realsense2_camera
 {
@@ -35,7 +36,7 @@ namespace realsense2_camera
     const stream_index_pair GYRO{RS2_STREAM_GYRO, 0};
     const stream_index_pair ACCEL{RS2_STREAM_ACCEL, 0};
     const stream_index_pair POSE{RS2_STREAM_POSE, 0};
-    
+
 
     const std::vector<stream_index_pair> IMAGE_STREAMS = {DEPTH, INFRA1, INFRA2,
                                                           COLOR,
@@ -57,21 +58,36 @@ namespace realsense2_camera
     public:
         RealSenseNodeFactory();
         virtual ~RealSenseNodeFactory();
-
     private:
-        static void closeDevice();
         void StartDevice();
         void change_device_callback(rs2::event_information& info);
         rs2::device getDevice();
         virtual void onInit() override;
+        void initialize(const ros::WallTimerEvent &ignored);
         void tryGetLogSeverity(rs2_log_severity& severity) const;
+        bool shutdown();
+        bool reset();
+        bool handleShutdown(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
+        bool handleReset(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
+        void dataMonitor(const ros::TimerEvent &e);
 
         rs2::device _device;
-        std::unique_ptr<InterfaceRealSenseNode> _realSenseNode;
+
+        std::shared_ptr<InterfaceRealSenseNode> _realSenseNode;
         rs2::context _ctx;
         std::string _serial_no;
         bool _initial_reset;
         std::thread _query_thread;
         bool _is_alive;
+        bool _initialized;
+        double _data_timeout;
+
+        enum TimeoutAction { TIMEOUT_WARN, TIMEOUT_RESET, TIMEOUT_SHUTDOWN };
+        TimeoutAction _timeout_action;
+
+        ros::WallTimer _init_timer;
+        ros::Timer _data_monitor_timer;
+        ros::ServiceServer _shutdown_srv;
+        ros::ServiceServer _reset_srv;
     };
 }//end namespace

--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -21,6 +21,7 @@
 #include <csignal>
 #include <eigen3/Eigen/Geometry>
 #include <fstream>
+#include <thread>
 
 namespace realsense2_camera
 {
@@ -55,10 +56,9 @@ namespace realsense2_camera
     {
     public:
         RealSenseNodeFactory();
-        virtual ~RealSenseNodeFactory() {}
+        virtual ~RealSenseNodeFactory();
 
     private:
-        static void signalHandler(int signum);
         static void closeDevice();
         void StartDevice();
         void change_device_callback(rs2::event_information& info);
@@ -66,9 +66,12 @@ namespace realsense2_camera
         virtual void onInit() override;
         void tryGetLogSeverity(rs2_log_severity& severity) const;
 
+        rs2::device _device;
         std::unique_ptr<InterfaceRealSenseNode> _realSenseNode;
         rs2::context _ctx;
         std::string _serial_no;
         bool _initial_reset;
+        std::thread _query_thread;
+        bool _is_alive;
     };
 }//end namespace

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -128,12 +128,19 @@ BaseRealSenseNode::~BaseRealSenseNode()
     std::set<std::string> module_names;
     for (const std::pair<stream_index_pair, std::vector<rs2::stream_profile>>& profile : _enabled_profiles)
     {
-        std::string module_name = _sensors[profile.first].get_info(RS2_CAMERA_INFO_NAME);
-        std::pair< std::set<std::string>::iterator, bool> res = module_names.insert(module_name);
-        if (res.second)
+        try
         {
-            _sensors[profile.first].stop();
-            _sensors[profile.first].close();
+            std::string module_name = _sensors[profile.first].get_info(RS2_CAMERA_INFO_NAME);
+            std::pair< std::set<std::string>::iterator, bool> res = module_names.insert(module_name);
+            if (res.second)
+            {
+                _sensors[profile.first].stop();
+                _sensors[profile.first].close();
+            }
+        }
+        catch (const rs2::error& e)
+        {
+            ROS_ERROR_STREAM("Exception: " << e.what());
         }
     }
 }
@@ -669,6 +676,9 @@ void BaseRealSenseNode::setupPublishers()
             _image_publishers[stream] = {image_transport.advertise(image_raw.str(), 1), frequency_diagnostics};
             _info_publisher[stream] = _node_handle.advertise<sensor_msgs::CameraInfo>(camera_info.str(), 1);
 
+            addMonitoredTopic(stream, TOPIC_IMAGE, image_raw.str());
+            addMonitoredTopic(stream, TOPIC_INFO, camera_info.str());
+
             if (_align_depth && (stream != DEPTH) && stream.second < 2)
             {
                 std::stringstream aligned_image_raw, aligned_camera_info;
@@ -679,11 +689,15 @@ void BaseRealSenseNode::setupPublishers()
                 std::shared_ptr<FrequencyDiagnostics> frequency_diagnostics(new FrequencyDiagnostics(_fps[stream], aligned_stream_name, _serial_no));
                 _depth_aligned_image_publishers[stream] = {image_transport.advertise(aligned_image_raw.str(), 1), frequency_diagnostics};
                 _depth_aligned_info_publisher[stream] = _node_handle.advertise<sensor_msgs::CameraInfo>(aligned_camera_info.str(), 1);
+
+            addMonitoredTopic(stream, TOPIC_ALIGNED_IMAGE, aligned_image_raw.str());
+            addMonitoredTopic(stream, TOPIC_ALIGNED_INFO, aligned_camera_info.str());
             }
 
             if (stream == DEPTH && _pointcloud)
             {
                 _pointcloud_publisher = _node_handle.advertise<sensor_msgs::PointCloud2>("depth/color/points", 1);
+                addMonitoredTopic(stream, TOPIC_POINTS, "depth/color/points");
             }
         }
     }
@@ -696,6 +710,9 @@ void BaseRealSenseNode::setupPublishers()
         _synced_imu_publisher->Enable(_hold_back_imu_for_frames);
 
         _info_publisher[GYRO] = _node_handle.advertise<IMUInfo>("imu_info", 1, true);
+
+        addMonitoredTopic(GYRO, TOPIC_IMU, "imu");
+        addMonitoredTopic(GYRO, TOPIC_INFO, "imu_info");
     }
     else
     {
@@ -703,17 +720,22 @@ void BaseRealSenseNode::setupPublishers()
         {
             _imu_publishers[GYRO] = _node_handle.advertise<sensor_msgs::Imu>("gyro/sample", 100);
             _info_publisher[GYRO] = _node_handle.advertise<IMUInfo>("gyro/imu_info", 1, true);
+            addMonitoredTopic(GYRO, TOPIC_IMU, "gyro/sample");
+            addMonitoredTopic(GYRO, TOPIC_INFO, "gyro/imu_info");
         }
 
         if (_enable[ACCEL])
         {
             _imu_publishers[ACCEL] = _node_handle.advertise<sensor_msgs::Imu>("accel/sample", 100);
             _info_publisher[ACCEL] = _node_handle.advertise<IMUInfo>("accel/imu_info", 1, true);
+            addMonitoredTopic(GYRO, TOPIC_IMU, "accel/sample");
+            addMonitoredTopic(GYRO, TOPIC_INFO, "accel/imu_info");
         }
     }
     if (_enable[POSE])
     {
         _imu_publishers[POSE] = _node_handle.advertise<nav_msgs::Odometry>("odom/sample", 100);
+        addMonitoredTopic(POSE, TOPIC_ODOM, "odom/sample");
     }
 
 
@@ -740,6 +762,47 @@ void BaseRealSenseNode::setupPublishers()
     {
         _depth_to_other_extrinsics_publishers[INFRA2] = _node_handle.advertise<Extrinsics>("extrinsics/depth_to_infra2", 1, true);
     }
+}
+
+void BaseRealSenseNode::addMonitoredTopic(const stream_index_pair& stream, Topic topic, const std::string& name)
+{
+    const std::lock_guard<std::mutex> lock(_topic_monitor_mutex);
+    TopicInfo info;
+    info.name = name;
+    info.resolved_name = _node_handle.resolveName(name);
+    info.last_published = ros::TIME_MIN;
+    _topics[stream][topic] = info;
+}
+
+void BaseRealSenseNode::updateMonitoredTopic(const stream_index_pair& stream, Topic topic)
+{
+    const std::lock_guard<std::mutex> lock(_topic_monitor_mutex);
+    _topics[stream][topic].last_published = ros::Time::now();
+}
+
+void BaseRealSenseNode::clearMonitoredTopic(const stream_index_pair& stream, Topic topic)
+{
+    const std::lock_guard<std::mutex> lock(_topic_monitor_mutex);
+    _topics[stream][topic].last_published = ros::TIME_MIN;
+}
+
+bool BaseRealSenseNode::checkTopics(const ros::Time& timeout, std::vector<std::string>& stale_topics)
+{
+    bool ok = true;
+    const std::lock_guard<std::mutex> lock(_topic_monitor_mutex);
+    for (const auto& stream: _topics)
+    {
+        for (const auto& topic: stream.second)
+        {
+            if (topic.second.last_published != ros::TIME_MIN && topic.second.last_published < timeout)
+            {
+                ok = false;
+                stale_topics.push_back(topic.second.name + ": " + topic.second.resolved_name);
+            }
+        }
+    }
+
+    return ok;
 }
 
 void BaseRealSenseNode::publishAlignedDepthToOthers(rs2::frameset frames, const ros::Time& t)
@@ -781,7 +844,13 @@ void BaseRealSenseNode::publishAlignedDepthToOthers(rs2::frameset frames, const 
                          _depth_aligned_info_publisher,
                          _depth_aligned_image_publishers, _depth_aligned_seq,
                          _depth_aligned_camera_info, _optical_frame_id,
-                         _depth_aligned_encoding);
+                         _depth_aligned_encoding,
+                         true, true);
+        }
+        else
+        {
+            clearMonitoredTopic(sip, TOPIC_ALIGNED_INFO);
+            clearMonitoredTopic(sip, TOPIC_ALIGNED_IMAGE);
         }
     }
 }
@@ -1204,6 +1273,10 @@ void BaseRealSenseNode::imu_callback_sync(rs2::frame frame, imu_sync_method sync
             _synced_imu_publisher->Publish(imu_msg);
             ROS_DEBUG("Publish united %s stream", rs2_stream_to_string(frame.get_profile().stream_type()));
         }
+        else
+        {
+            clearMonitoredTopic(stream_index, TOPIC_IMU);
+        }
         break;
     }
     m_mutex.unlock();
@@ -1259,7 +1332,12 @@ void BaseRealSenseNode::imu_callback(rs2::frame frame)
         imu_msg.header.seq = _seq[stream_index];
         imu_msg.header.stamp = t;
         _imu_publishers[stream_index].publish(imu_msg);
+        updateMonitoredTopic(stream_index, TOPIC_IMU);
         ROS_DEBUG("Publish %s stream", rs2_stream_to_string(frame.get_profile().stream_type()));
+    }
+    else
+    {
+        clearMonitoredTopic(stream_index, TOPIC_IMU);
     }
 }
 
@@ -1352,7 +1430,12 @@ void BaseRealSenseNode::pose_callback(rs2::frame frame)
                                     0, 0, 0, 0, cov_twist, 0,
                                     0, 0, 0, 0, 0, cov_twist};
         _imu_publishers[stream_index].publish(odom_msg);
+        updateMonitoredTopic(stream_index, TOPIC_ODOM);
         ROS_DEBUG("Publish %s stream", rs2_stream_to_string(frame.get_profile().stream_type()));
+    }
+    else
+    {
+        clearMonitoredTopic(stream_index, TOPIC_ODOM);
     }
 }
 
@@ -1482,10 +1565,11 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
 
                 if (f.is<rs2::points>())
                 {
-                    if (0 != _pointcloud_publisher.getNumSubscribers())
+                    if (_pointcloud)
                     {
                         ROS_DEBUG("Publish pointscloud");
                         publishPointCloud(f.as<rs2::points>(), t, frameset);
+                        updateMonitoredTopic(DEPTH, TOPIC_POINTS);
                     }
                     continue;
                 }
@@ -1832,7 +1916,6 @@ void BaseRealSenseNode::publishStaticTransforms()
         _depth_to_other_extrinsics[INFRA2] = ex;
         _depth_to_other_extrinsics_publishers[INFRA2].publish(rsExtrinsicsToMsg(ex, frame_id));
     }
-
 }
 
 void reverse_memcpy(unsigned char* dst, const unsigned char* src, size_t n)
@@ -2053,7 +2136,8 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const ros::Time& t,
                                      std::map<stream_index_pair, sensor_msgs::CameraInfo>& camera_info,
                                      const std::map<stream_index_pair, std::string>& optical_frame_id,
                                      const std::map<rs2_stream, std::string>& encoding,
-                                     bool copy_data_from_frame)
+                                     bool copy_data_from_frame,
+                                     bool aligned)
 {
     ROS_DEBUG("publishFrame(...)");
     unsigned int width = 0;
@@ -2104,8 +2188,33 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const ros::Time& t,
 
         image_publisher.first.publish(img);
         image_publisher.second->update();
+
         // ROS_INFO_STREAM("fid: " << cam_info.header.seq << ", time: " << std::setprecision (20) << t.toSec());
         ROS_DEBUG("%s stream published", rs2_stream_to_string(f.get_profile().stream_type()));
+
+        if (aligned)
+        {
+            updateMonitoredTopic(stream, TOPIC_ALIGNED_INFO);
+            updateMonitoredTopic(stream, TOPIC_ALIGNED_IMAGE);
+        }
+        else
+        {
+            updateMonitoredTopic(stream, TOPIC_INFO);
+            updateMonitoredTopic(stream, TOPIC_IMAGE);
+        }
+    }
+    else
+    {
+        if (aligned)
+        {
+            clearMonitoredTopic(stream, TOPIC_ALIGNED_INFO);
+            clearMonitoredTopic(stream, TOPIC_ALIGNED_IMAGE);
+        }
+        else
+        {
+            clearMonitoredTopic(stream, TOPIC_INFO);
+            clearMonitoredTopic(stream, TOPIC_IMAGE);
+        }
     }
 }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -123,6 +123,21 @@ BaseRealSenseNode::BaseRealSenseNode(ros::NodeHandle& nodeHandle,
     _stream_name[RS2_STREAM_POSE] = "pose";
 }
 
+BaseRealSenseNode::~BaseRealSenseNode()
+{
+    std::set<std::string> module_names;
+    for (const std::pair<stream_index_pair, std::vector<rs2::stream_profile>>& profile : _enabled_profiles)
+    {
+        std::string module_name = _sensors[profile.first].get_info(RS2_CAMERA_INFO_NAME);
+        std::pair< std::set<std::string>::iterator, bool> res = module_names.insert(module_name);
+        if (res.second)
+        {
+            _sensors[profile.first].stop();
+            _sensors[profile.first].close();
+        }
+    }
+}
+
 void BaseRealSenseNode::toggleSensors(bool enabled)
 {
     for (auto it=_sensors.begin(); it != _sensors.end(); it++)

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -13,6 +13,9 @@
 #include <sys/time.h>
 #include <chrono>
 
+#include <nodelet/NodeletUnload.h>
+
+
 using namespace realsense2_camera;
 
 #define REALSENSE_ROS_EMBEDDED_VERSION_STR (VAR_ARG_STRING(VERSION: REALSENSE_ROS_MAJOR_VERSION.REALSENSE_ROS_MINOR_VERSION.REALSENSE_ROS_PATCH_VERSION))
@@ -21,7 +24,8 @@ constexpr auto realsense_ros_camera_version = REALSENSE_ROS_EMBEDDED_VERSION_STR
 PLUGINLIB_EXPORT_CLASS(realsense2_camera::RealSenseNodeFactory, nodelet::Nodelet)
 
 RealSenseNodeFactory::RealSenseNodeFactory() :
-	_is_alive(true)
+	_is_alive(true),
+	_initialized(false)
 {
 	ROS_INFO("RealSense ROS v%s", REALSENSE_ROS_VERSION_STR);
 	ROS_INFO("Running with LibRealSense v%s", RS2_API_VERSION_STR);
@@ -36,10 +40,26 @@ RealSenseNodeFactory::RealSenseNodeFactory() :
 
 RealSenseNodeFactory::~RealSenseNodeFactory()
 {
-	_is_alive = false;
-	if (_query_thread.joinable())
+	try
 	{
-		_query_thread.join();
+		_initialized = false;
+		_data_monitor_timer.stop();
+		_is_alive = false;
+		if (_query_thread.joinable())
+		{
+			_query_thread.join();
+		}
+
+		_realSenseNode.reset();
+		if (_device)
+		{
+			_device.hardware_reset();
+			_device = rs2::device();
+		}
+	}
+	catch (const rs2::error& e)
+	{
+		ROS_ERROR_STREAM("Exception: " << e.what());
 	}
 }
 
@@ -83,29 +103,29 @@ rs2::device RealSenseNodeFactory::getDevice()
 
 void RealSenseNodeFactory::change_device_callback(rs2::event_information& info)
 {
-	if (info.was_removed(_device))
+	if (_initialized)
 	{
-		ROS_ERROR("The device has been disconnected!");
-		_realSenseNode.reset(nullptr);
-		_device = rs2::device();
-	}
-	if (!_device)
-	{
-		rs2::device_list new_devices = info.get_new_devices();
-		if (new_devices.size() > 0)
+		if (info.was_removed(_device))
 		{
-			ROS_INFO("Checking new devices...");
-			_device = getDevice();
-			if (_device)
-			{
-				StartDevice();
-			}
+			ROS_ERROR("The device has been disconnected!");
+			ROS_ERROR("Shutting down ...");
+			shutdown();
 		}
 	}
 }
 
 void RealSenseNodeFactory::onInit()
 {
+	auto nh = getNodeHandle();
+	auto privateNh = getPrivateNodeHandle();
+
+	privateNh.param("initial_reset", _initial_reset, false);
+	_init_timer = nh.createWallTimer(ros::WallDuration(1.0), &RealSenseNodeFactory::initialize, this, true);
+}
+
+void RealSenseNodeFactory::initialize(const ros::WallTimerEvent &ignored)
+{
+	_device = rs2::device();
 	try
 	{
 #ifdef BPDEBUG
@@ -116,6 +136,26 @@ void RealSenseNodeFactory::onInit()
 		ros::NodeHandle nh = getNodeHandle();
 		auto privateNh = getPrivateNodeHandle();
 		privateNh.param("serial_no", _serial_no, std::string(""));
+
+		std::string timeout_action;
+		privateNh.param("timeout_action", timeout_action, std::string("warn"));
+		if (timeout_action == "warn")
+		{
+			_timeout_action = TIMEOUT_WARN;
+		}
+		else if (timeout_action == "reset")
+		{
+			_timeout_action = TIMEOUT_RESET;
+		}
+		else if (timeout_action == "shutdown")
+		{
+			_timeout_action = TIMEOUT_SHUTDOWN;
+		}
+		else
+		{
+			_timeout_action = TIMEOUT_WARN;
+			ROS_WARN("Invalid timeout_action (warn|reset|shutdown): %s", timeout_action.c_str());
+		}
 
 		std::string rosbag_filename("");
 		privateNh.param("rosbag_filename", rosbag_filename, std::string(""));
@@ -128,25 +168,41 @@ void RealSenseNodeFactory::onInit()
 			cfg.enable_all_streams();
 			pipe->start(cfg); //File will be opened in read mode at this point
 			_device = pipe->get_active_profile().get_device();
-			_realSenseNode = std::unique_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
+			_realSenseNode = std::shared_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
 			_realSenseNode->publishTopics();
 			_realSenseNode->registerDynamicReconfigCb(nh);
 		}
 		else
 		{
-			privateNh.param("initial_reset", _initial_reset, false);
-
+			_is_alive = true;
 			_query_thread = std::thread([=]()
 						{
+							ROS_DEBUG("Waiting for device...");
+
+ 
 							std::chrono::milliseconds timespan(6000);
 							while (_is_alive && !_device)
 							{
-								getDevice();
+								ROS_DEBUG("Checking for device...");
+								_device = getDevice();
 								if (_device)
 								{
-									std::function<void(rs2::event_information&)> change_device_callback_function = [this](rs2::event_information& info){change_device_callback(info);};
-									_ctx.set_devices_changed_callback(change_device_callback_function);
-									StartDevice();
+									ROS_DEBUG("got device");
+									if (_initial_reset)
+									{
+										ROS_DEBUG("Resetting device...");
+										_initial_reset = false;
+										_device.hardware_reset();
+										std::this_thread::sleep_for(std::chrono::seconds(10));
+										_device = getDevice();
+									}
+									if (_device)
+									{
+										ROS_DEBUG("starting device...");
+										std::function<void(rs2::event_information&)> change_device_callback_function = [this](rs2::event_information& info){change_device_callback(info);};
+										_ctx.set_devices_changed_callback(change_device_callback_function);
+										StartDevice();
+									}
 								}
 								else
 								{
@@ -154,11 +210,15 @@ void RealSenseNodeFactory::onInit()
 								}
 							}
 						});
-		}
 
-		if (_device)
-		{
-			StartDevice();
+			if (!_shutdown_srv)
+			{
+				_shutdown_srv = privateNh.advertiseService("shutdown", &RealSenseNodeFactory::handleShutdown, this);
+			}
+			if (!_reset_srv)
+			{
+				_reset_srv = privateNh.advertiseService("reset", &RealSenseNodeFactory::handleReset, this);
+			}
 		}
 	}
 	catch(const std::exception& ex)
@@ -173,8 +233,54 @@ void RealSenseNodeFactory::onInit()
 	}
 }
 
+void RealSenseNodeFactory::dataMonitor(const ros::TimerEvent &e)
+{
+	if (!_realSenseNode || _data_timeout <= 0.0)
+	{
+		return;
+	}
+
+	ros::Time timeout = e.current_real - ros::Duration(_data_timeout);
+
+	std::vector<std::string> stale_topics;
+	if (!std::dynamic_pointer_cast<BaseRealSenseNode>(_realSenseNode)->checkTopics(timeout, stale_topics))
+	{
+		if (_timeout_action == TIMEOUT_WARN)
+		{
+			std::string stale_topic_string;
+			for (const auto& topic: stale_topics)
+			{
+				stale_topic_string += topic + ", ";
+			}
+			ROS_WARN_THROTTLE(1.0, "Realsense data timed out. Stale topics: %s", stale_topic_string.c_str());
+		}
+		else if (_timeout_action == TIMEOUT_RESET)
+		{
+			ROS_ERROR("Realsense data timed out. Resetting driver.");
+			ROS_ERROR("The following topics were stale:");
+			for (const auto& topic: stale_topics)
+			{
+				ROS_ERROR("  %s", topic.c_str());
+			}
+			reset();
+		}
+		else if (_timeout_action == TIMEOUT_SHUTDOWN)
+		{
+			ROS_ERROR("Realsense data timed out. Shutting down driver.");
+			ROS_ERROR("The following topics were stale:");
+			for (const auto& topic: stale_topics)
+			{
+				ROS_ERROR("  %s", topic.c_str());
+			}
+			shutdown();
+		}
+	}
+}
+
 void RealSenseNodeFactory::StartDevice()
 {
+	try
+	{
 	ros::NodeHandle nh = getNodeHandle();
 	ros::NodeHandle privateNh = getPrivateNodeHandle();
 	// TODO
@@ -196,10 +302,10 @@ void RealSenseNodeFactory::StartDevice()
 	case RS435_RGB_PID:
 	case RS435i_RGB_PID:
 	case RS_USB2_PID:
-		_realSenseNode = std::unique_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
+		_realSenseNode = std::shared_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
 		break;
 	case RS_T265_PID:
-		_realSenseNode = std::unique_ptr<T265RealsenseNode>(new T265RealsenseNode(nh, privateNh, _device, _serial_no));
+		_realSenseNode = std::shared_ptr<T265RealsenseNode>(new T265RealsenseNode(nh, privateNh, _device, _serial_no));
 		break;
 	default:
 		ROS_FATAL_STREAM("Unsupported device!" << " Product ID: 0x" << pid_str);
@@ -209,6 +315,96 @@ void RealSenseNodeFactory::StartDevice()
 	assert(_realSenseNode);
 	_realSenseNode->publishTopics();
 	_realSenseNode->registerDynamicReconfigCb(nh);
+
+	_initialized = true;
+
+	_data_timeout = privateNh.param("data_timeout", 0.0);
+	if (_data_timeout > 0.0)
+	{
+		ROS_INFO("starting data monitor ...");
+		_data_monitor_timer = nh.createTimer(ros::Duration(_data_timeout), &RealSenseNodeFactory::dataMonitor, this, false);
+	}
+	else
+	{
+		ROS_INFO("not monitoring data.");
+	}
+  }
+	catch (const rs2::error& e)
+	{
+		ROS_ERROR_STREAM("Exception: " << e.what());
+	}
+}
+
+bool RealSenseNodeFactory::shutdown()
+{
+	_initialized = false;
+	_data_monitor_timer.stop();
+
+	std::string manager_name = ros::this_node::getName();
+	std::string unload_service = manager_name + "/unload_nodelet";
+
+	if (ros::service::waitForService(unload_service, 0.1))
+	{
+		nodelet::NodeletUnload srv;
+		srv.request.name = getName();
+		if (!ros::service::call(unload_service, srv) || !srv.response.success)
+		{
+			ROS_WARN("Failed to unload nodelet, requesting shutdown ...");
+			ros::requestShutdown();
+		}
+	}
+	else
+	{
+		ROS_WARN("Failed to find unload nodelet service, requesting shutdown ...");
+		ros::requestShutdown();
+	}
+
+	return true;
+}
+
+bool RealSenseNodeFactory::reset()
+{
+	if (!_initialized)
+	{
+		return false;
+	}
+
+	_initialized = false;
+
+	_data_monitor_timer.stop();
+
+	_is_alive = false;
+	if (_query_thread.joinable())
+	{
+		_query_thread.join();
+	}
+
+	try
+	{
+	_realSenseNode.reset();
+		if (_device)
+		{
+			_device.hardware_reset();
+			_device = rs2::device();
+		}
+	}
+	catch (const rs2::error& e)
+	{
+		ROS_ERROR_STREAM("Exception: " << e.what());
+	}
+
+	_init_timer = getNodeHandle().createWallTimer(ros::WallDuration(1.0), &RealSenseNodeFactory::initialize, this, true);
+	return true;
+}
+
+bool RealSenseNodeFactory::handleShutdown(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response)
+{
+	return shutdown();
+}
+
+bool RealSenseNodeFactory::handleReset(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response)
+{
+	return reset();
 }
 
 void RealSenseNodeFactory::tryGetLogSeverity(rs2_log_severity& severity) const


### PR DESCRIPTION
* Add support for cleanly shutting down driver nodelet without killing nodelet manager.
* Add support for resetting driver without killing nodelet manager.
* Add services to shutdown or reset driver cleanly.
* Add support for monitoring published topics to detect data timeouts, which have been observed, but are not easy to reproduce.
* Add support for automatically resetting or shutting down driver when a data timeout is detected.