### PR TITLE
Revert upstream changes to to run initialization on a separate thread

### DIFF
--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -77,8 +77,6 @@ namespace realsense2_camera
         rs2::context _ctx;
         std::string _serial_no;
         bool _initial_reset;
-        std::thread _query_thread;
-        bool _is_alive;
         bool _initialized;
         double _data_timeout;
 


### PR DESCRIPTION
Revert upstream changes to to run initialization on a separate thread, instead have the driver unload itself or shutdown if no device is found.

This will rely on roslaunch respawn to accomplish polling for the device if it isn't present.  I think this is a bit simpler and avoids needing a special thread for initialization.