### PR TITLE
[Cherry-pick] Support cleanly resetting driver and hot-plugging sensors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ Setting *unite_imu_method* creates a new topic, *imu*, that replaces the default
 - **publish_tf**: boolean, publish or not TF at all. Defaults to True.
 - **tf_publish_rate**: double, positive values mean dynamic transform publication with specified rate, all other values mean static transform publication. Defaults to 0 
 - **publish_odom_tf**: If True (default) publish TF from odom_frame to pose_frame.
+- **infrargb**: When set to True (default: False), it configures the infrared camera to stream in RGB (color) mode, thus enabling the use of a RGB image in the same frame as the depth image, potentially avoiding frame transformation related errors. When this feature is required, you are additionally required to also enable `enable_infra:=true` for the infrared stream to be enabled.
+  - **NOTE** The configuration required for `enable_infra` is independent of `enable_depth`
+  - **NOTE** To enable the Infrared stream, you should enable `enable_infra:=true` NOT `enable_infra1:=true` nor `enable_infra2:=true`
+  - **NOTE** This feature is only supported by Realsense sensors with RGB streams available from the `infra` cameras, which can be checked by observing the output of `rs-enumerate-devices`
 
 
 ### RGBD Point Cloud

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -18,6 +18,7 @@
 #include <condition_variable>
 
 #include <queue>
+#include <map>
 #include <mutex>
 #include <atomic>
 #include <string>
@@ -324,6 +325,20 @@ namespace realsense2_camera
 
         sensor_msgs::PointCloud2 _msg_pointcloud;
         std::vector< unsigned int > _valid_pc_indices;
+
+        // Topic monitoring
+        enum Topic { TOPIC_IMAGE, TOPIC_INFO, TOPIC_ALIGNED_IMAGE, TOPIC_ALIGNED_INFO, TOPIC_IMU, TOPIC_POINTS, TOPIC_ODOM};
+        struct TopicInfo
+        {
+            std::string name;
+            std::string resolved_name;
+            ros::Time last_published;
+        };
+        std::mutex _topic_monitor_mutex;
+        std::map<stream_index_pair, std::map<Topic, TopicInfo>> _topics;
+        void addMonitoredTopic(const stream_index_pair& stream, Topic topic, const std::string& name);
+        void updateMonitoredTopic(const stream_index_pair& stream, Topic topic);
+        void clearMonitoredTopic(const stream_index_pair& stream, Topic topic);
 
     };//end class
 

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -20,7 +20,9 @@
 #include <queue>
 #include <mutex>
 #include <atomic>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace realsense2_camera
 {
@@ -124,6 +126,8 @@ namespace realsense2_camera
         virtual void registerDynamicReconfigCb(ros::NodeHandle& nh) override;
         virtual ~BaseRealSenseNode();
 
+        bool checkTopics(const ros::Time& timeout, std::vector<std::string>& stale_topics);
+
     public:
         enum imu_sync_method{NONE, COPY, LINEAR_INTERPOLATION};
 
@@ -216,7 +220,8 @@ namespace realsense2_camera
                           std::map<stream_index_pair, sensor_msgs::CameraInfo>& camera_info,
                           const std::map<stream_index_pair, std::string>& optical_frame_id,
                           const std::map<rs2_stream, std::string>& encoding,
-                          bool copy_data_from_frame = true);
+                          bool copy_data_from_frame = true,
+                          bool aligned = false);
         bool getEnabledProfile(const stream_index_pair& stream_index, rs2::stream_profile& profile);
 
         void publishAlignedDepthToOthers(rs2::frameset frames, const ros::Time& t);

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -25,6 +25,7 @@
   <arg name="enable_infra"        default="false"/>
   <arg name="enable_infra1"       default="false"/>
   <arg name="enable_infra2"       default="false"/>
+  <arg name="enable_infrargb"    default="false"/>
 
   <arg name="color_width"         default="640"/>
   <arg name="color_height"        default="480"/>
@@ -126,6 +127,7 @@
     <param name="enable_infra"             type="bool" value="$(arg enable_infra)"/>
     <param name="enable_infra1"            type="bool" value="$(arg enable_infra1)"/>
     <param name="enable_infra2"            type="bool" value="$(arg enable_infra2)"/>
+    <param name="infrargb"                 type="bool" value="$(arg enable_infrargb)"/>
 
     <param name="fisheye_fps"              type="int"  value="$(arg fisheye_fps)"/>
     <param name="depth_fps"                type="int"  value="$(arg depth_fps)"/>

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -8,6 +8,7 @@
   <arg name="json_file_path"      default=""/>
   <arg name="rosbag_filename"     default=""/>
   <arg name="required"            default="false"/>
+  <arg name="respawn"             default="false" />
 
   <arg name="fisheye_width"       default="0"/>
   <arg name="fisheye_height"      default="0"/>
@@ -93,7 +94,7 @@
 
 
   <node unless="$(arg external_manager)" pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen" required="$(arg required)"/>
-  <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)" required="$(arg required)">
+  <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)" required="$(arg required)" respawn="$(arg respawn)">
     <param name="serial_no"                type="str"  value="$(arg serial_no)"/>
     <param name="usb_port_id"              type="str"  value="$(arg usb_port_id)"/>
     <param name="device_type"              type="str"  value="$(arg device_type)"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -22,6 +22,7 @@
   <arg name="enable_infra"        default="false"/>
   <arg name="enable_infra1"       default="false"/>
   <arg name="enable_infra2"       default="false"/>
+  <arg name="enable_infrargb"    default="false"/>
 
   <arg name="color_width"         default="640"/>
   <arg name="color_height"        default="480"/>
@@ -90,6 +91,7 @@
       <arg name="enable_infra"            value="$(arg enable_infra)"/>
       <arg name="enable_infra1"            value="$(arg enable_infra1)"/>
       <arg name="enable_infra2"            value="$(arg enable_infra2)"/>
+      <arg name="enable_infrargb"         value="$(arg enable_infrargb)"/>
 
       <arg name="fisheye_fps"              value="$(arg fisheye_fps)"/>
       <arg name="depth_fps"                value="$(arg depth_fps)"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -7,6 +7,7 @@
   <arg name="tf_prefix"           default="$(arg camera)"/>
   <arg name="external_manager"    default="false"/>
   <arg name="manager"             default="realsense2_camera_manager"/>
+  <arg name="respawn"             default="false" doc="if true, came realsense2_camera node respawns when crashed." />
 
   <arg name="fisheye_width"       default="640"/>
   <arg name="fisheye_height"      default="480"/>
@@ -64,6 +65,7 @@
       <arg name="usb_port_id"              value="$(arg usb_port_id)"/>
       <arg name="device_type"              value="$(arg device_type)"/>
       <arg name="json_file_path"           value="$(arg json_file_path)"/>
+      <arg name="respawn"                  value="$(arg respawn)" />
 
       <arg name="enable_pointcloud"        value="$(arg enable_pointcloud)"/>
       <arg name="pointcloud_texture_stream" value="$(arg pointcloud_texture_stream)"/>

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1391,11 +1391,10 @@ void BaseRealSenseNode::imu_callback_sync(rs2::frame frame, imu_sync_method sync
             ROS_DEBUG("Publish united %s stream", rs2_stream_to_string(frame.get_profile().stream_type()));
             imu_msgs.pop_front();
         }
-        else
-        {
-            clearMonitoredTopic(stream_index, TOPIC_IMU);
-        }
-        break;
+    }
+    else
+    {
+        clearMonitoredTopic(stream_index, TOPIC_IMU);
     }
     m_mutex.unlock();
 };

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -142,12 +142,19 @@ BaseRealSenseNode::~BaseRealSenseNode()
     std::set<std::string> module_names;
     for (const std::pair<stream_index_pair, std::vector<rs2::stream_profile>>& profile : _enabled_profiles)
     {
-        std::string module_name = _sensors[profile.first].get_info(RS2_CAMERA_INFO_NAME);
-        std::pair< std::set<std::string>::iterator, bool> res = module_names.insert(module_name);
-        if (res.second)
+        try
         {
-            _sensors[profile.first].stop();
-            _sensors[profile.first].close();
+            std::string module_name = _sensors[profile.first].get_info(RS2_CAMERA_INFO_NAME);
+            std::pair< std::set<std::string>::iterator, bool> res = module_names.insert(module_name);
+            if (res.second)
+            {
+                _sensors[profile.first].stop();
+                _sensors[profile.first].close();
+            }
+        }
+        catch (const rs2::error& e)
+        {
+            ROS_ERROR_STREAM("Exception: " << e.what());
         }
     }
 }
@@ -819,6 +826,9 @@ void BaseRealSenseNode::setupPublishers()
             _image_publishers[stream] = {image_transport.advertise(image_raw.str(), 1), frequency_diagnostics};
             _info_publisher[stream] = _node_handle.advertise<sensor_msgs::CameraInfo>(camera_info.str(), 1);
 
+            addMonitoredTopic(stream, TOPIC_IMAGE, image_raw.str());
+            addMonitoredTopic(stream, TOPIC_INFO, camera_info.str());
+
             if (_align_depth && (stream != DEPTH) && stream.second < 2)
             {
                 std::stringstream aligned_image_raw, aligned_camera_info;
@@ -829,11 +839,15 @@ void BaseRealSenseNode::setupPublishers()
                 std::shared_ptr<FrequencyDiagnostics> frequency_diagnostics(new FrequencyDiagnostics(_fps[stream], aligned_stream_name, _serial_no));
                 _depth_aligned_image_publishers[stream] = {image_transport.advertise(aligned_image_raw.str(), 1), frequency_diagnostics};
                 _depth_aligned_info_publisher[stream] = _node_handle.advertise<sensor_msgs::CameraInfo>(aligned_camera_info.str(), 1);
+
+            addMonitoredTopic(stream, TOPIC_ALIGNED_IMAGE, aligned_image_raw.str());
+            addMonitoredTopic(stream, TOPIC_ALIGNED_INFO, aligned_camera_info.str());
             }
 
             if (stream == DEPTH && _pointcloud)
             {
                 _pointcloud_publisher = _node_handle.advertise<sensor_msgs::PointCloud2>("depth/color/points", 1);
+                addMonitoredTopic(stream, TOPIC_POINTS, "depth/color/points");
             }
         }
     }
@@ -844,22 +858,34 @@ void BaseRealSenseNode::setupPublishers()
         ROS_INFO("Start publisher IMU");
         _synced_imu_publisher = std::make_shared<SyncedImuPublisher>(_node_handle.advertise<sensor_msgs::Imu>("imu", 5));
         _synced_imu_publisher->Enable(_hold_back_imu_for_frames);
+
+        _info_publisher[GYRO] = _node_handle.advertise<IMUInfo>("imu_info", 1, true);
+
+        addMonitoredTopic(GYRO, TOPIC_IMU, "imu");
+        addMonitoredTopic(GYRO, TOPIC_INFO, "imu_info");
     }
     else
     {
         if (_enable[GYRO])
         {
             _imu_publishers[GYRO] = _node_handle.advertise<sensor_msgs::Imu>("gyro/sample", 100);
+            _info_publisher[GYRO] = _node_handle.advertise<IMUInfo>("gyro/imu_info", 1, true);
+            addMonitoredTopic(GYRO, TOPIC_IMU, "gyro/sample");
+            addMonitoredTopic(GYRO, TOPIC_INFO, "gyro/imu_info");
         }
 
         if (_enable[ACCEL])
         {
             _imu_publishers[ACCEL] = _node_handle.advertise<sensor_msgs::Imu>("accel/sample", 100);
+            _info_publisher[ACCEL] = _node_handle.advertise<IMUInfo>("accel/imu_info", 1, true);
+            addMonitoredTopic(GYRO, TOPIC_IMU, "accel/sample");
+            addMonitoredTopic(GYRO, TOPIC_INFO, "accel/imu_info");
         }
     }
     if (_enable[POSE])
     {
         _imu_publishers[POSE] = _node_handle.advertise<nav_msgs::Odometry>("odom/sample", 100);
+        addMonitoredTopic(POSE, TOPIC_ODOM, "odom/sample");
     }
 
 
@@ -886,6 +912,47 @@ void BaseRealSenseNode::setupPublishers()
     {
         _depth_to_other_extrinsics_publishers[INFRA2] = _node_handle.advertise<Extrinsics>("extrinsics/depth_to_infra2", 1, true);
     }
+}
+
+void BaseRealSenseNode::addMonitoredTopic(const stream_index_pair& stream, Topic topic, const std::string& name)
+{
+    const std::lock_guard<std::mutex> lock(_topic_monitor_mutex);
+    TopicInfo info;
+    info.name = name;
+    info.resolved_name = _node_handle.resolveName(name);
+    info.last_published = ros::TIME_MIN;
+    _topics[stream][topic] = info;
+}
+
+void BaseRealSenseNode::updateMonitoredTopic(const stream_index_pair& stream, Topic topic)
+{
+    const std::lock_guard<std::mutex> lock(_topic_monitor_mutex);
+    _topics[stream][topic].last_published = ros::Time::now();
+}
+
+void BaseRealSenseNode::clearMonitoredTopic(const stream_index_pair& stream, Topic topic)
+{
+    const std::lock_guard<std::mutex> lock(_topic_monitor_mutex);
+    _topics[stream][topic].last_published = ros::TIME_MIN;
+}
+
+bool BaseRealSenseNode::checkTopics(const ros::Time& timeout, std::vector<std::string>& stale_topics)
+{
+    bool ok = true;
+    const std::lock_guard<std::mutex> lock(_topic_monitor_mutex);
+    for (const auto& stream: _topics)
+    {
+        for (const auto& topic: stream.second)
+        {
+            if (topic.second.last_published != ros::TIME_MIN && topic.second.last_published < timeout)
+            {
+                ok = false;
+                stale_topics.push_back(topic.second.name + ": " + topic.second.resolved_name);
+            }
+        }
+    }
+
+    return ok;
 }
 
 void BaseRealSenseNode::publishAlignedDepthToOthers(rs2::frameset frames, const ros::Time& t)
@@ -927,7 +994,13 @@ void BaseRealSenseNode::publishAlignedDepthToOthers(rs2::frameset frames, const 
                          _depth_aligned_info_publisher,
                          _depth_aligned_image_publishers, _depth_aligned_seq,
                          _depth_aligned_camera_info, _optical_frame_id,
-                         _depth_aligned_encoding);
+                         _depth_aligned_encoding,
+                         true, true);
+        }
+        else
+        {
+            clearMonitoredTopic(sip, TOPIC_ALIGNED_INFO);
+            clearMonitoredTopic(sip, TOPIC_ALIGNED_IMAGE);
         }
     }
 }
@@ -1318,6 +1391,11 @@ void BaseRealSenseNode::imu_callback_sync(rs2::frame frame, imu_sync_method sync
             ROS_DEBUG("Publish united %s stream", rs2_stream_to_string(frame.get_profile().stream_type()));
             imu_msgs.pop_front();
         }
+        else
+        {
+            clearMonitoredTopic(stream_index, TOPIC_IMU);
+        }
+        break;
     }
     m_mutex.unlock();
 };
@@ -1364,7 +1442,12 @@ void BaseRealSenseNode::imu_callback(rs2::frame frame)
         imu_msg.header.seq = _seq[stream_index];
         imu_msg.header.stamp = t;
         _imu_publishers[stream_index].publish(imu_msg);
+        updateMonitoredTopic(stream_index, TOPIC_IMU);
         ROS_DEBUG("Publish %s stream", rs2_stream_to_string(frame.get_profile().stream_type()));
+    }
+    else
+    {
+        clearMonitoredTopic(stream_index, TOPIC_IMU);
     }
 }
 
@@ -1457,7 +1540,12 @@ void BaseRealSenseNode::pose_callback(rs2::frame frame)
                                     0, 0, 0, 0, cov_twist, 0,
                                     0, 0, 0, 0, 0, cov_twist};
         _imu_publishers[stream_index].publish(odom_msg);
+        updateMonitoredTopic(stream_index, TOPIC_ODOM);
         ROS_DEBUG("Publish %s stream", rs2_stream_to_string(frame.get_profile().stream_type()));
+    }
+    else
+    {
+        clearMonitoredTopic(stream_index, TOPIC_ODOM);
     }
 }
 
@@ -1582,10 +1670,11 @@ void BaseRealSenseNode::frame_callback(rs2::frame frame)
 
                 if (f.is<rs2::points>())
                 {
-                    if (0 != _pointcloud_publisher.getNumSubscribers())
+                    if (_pointcloud)
                     {
                         ROS_DEBUG("Publish pointscloud");
                         publishPointCloud(f.as<rs2::points>(), t, frameset);
+                        updateMonitoredTopic(DEPTH, TOPIC_POINTS);
                     }
                     continue;
                 }
@@ -1941,7 +2030,6 @@ void BaseRealSenseNode::publishStaticTransforms()
         _depth_to_other_extrinsics[INFRA2] = ex;
         _depth_to_other_extrinsics_publishers[INFRA2].publish(rsExtrinsicsToMsg(ex, frame_id));
     }
-
 }
 
 void BaseRealSenseNode::publishDynamicTransforms()
@@ -2188,7 +2276,8 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const ros::Time& t,
                                      std::map<stream_index_pair, sensor_msgs::CameraInfo>& camera_info,
                                      const std::map<stream_index_pair, std::string>& optical_frame_id,
                                      const std::map<rs2_stream, std::string>& encoding,
-                                     bool copy_data_from_frame)
+                                     bool copy_data_from_frame,
+                                     bool aligned)
 {
     ROS_DEBUG("publishFrame(...)");
     unsigned int width = 0;
@@ -2243,8 +2332,33 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const ros::Time& t,
 
         image_publisher.first.publish(img);
         image_publisher.second->update();
+
         // ROS_INFO_STREAM("fid: " << cam_info.header.seq << ", time: " << std::setprecision (20) << t.toSec());
         ROS_DEBUG("%s stream published", rs2_stream_to_string(f.get_profile().stream_type()));
+
+        if (aligned)
+        {
+            updateMonitoredTopic(stream, TOPIC_ALIGNED_INFO);
+            updateMonitoredTopic(stream, TOPIC_ALIGNED_IMAGE);
+        }
+        else
+        {
+            updateMonitoredTopic(stream, TOPIC_INFO);
+            updateMonitoredTopic(stream, TOPIC_IMAGE);
+        }
+    }
+    else
+    {
+        if (aligned)
+        {
+            clearMonitoredTopic(stream, TOPIC_ALIGNED_INFO);
+            clearMonitoredTopic(stream, TOPIC_ALIGNED_IMAGE);
+        }
+        else
+        {
+            clearMonitoredTopic(stream, TOPIC_INFO);
+            clearMonitoredTopic(stream, TOPIC_IMAGE);
+        }
     }
 }
 

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -308,31 +308,17 @@ void RealSenseNodeFactory::initialize(const ros::WallTimerEvent &ignored)
 						{
 							ROS_DEBUG("Waiting for device...");
 
- 
 							std::chrono::milliseconds timespan(6000);
 							while (_is_alive && !_device)
 							{
 								ROS_DEBUG("Checking for device...");
-								_device = getDevice();
- 								// getDevice(_ctx.query_devices());  // This line is obtained from the latest upstream.
+								getDevice(_ctx.query_devices());
 								if (_device)
 								{
-									ROS_DEBUG("got device");
-									if (_initial_reset)
-									{
-										ROS_DEBUG("Resetting device...");
-										_initial_reset = false;
-										_device.hardware_reset();
-										std::this_thread::sleep_for(std::chrono::seconds(10));
-										_device = getDevice();
-									}
-									if (_device)
-									{
-										ROS_DEBUG("starting device...");
-										std::function<void(rs2::event_information&)> change_device_callback_function = [this](rs2::event_information& info){change_device_callback(info);};
-										_ctx.set_devices_changed_callback(change_device_callback_function);
-										StartDevice();
-									}
+									ROS_DEBUG("starting device...");
+									std::function<void(rs2::event_information&)> change_device_callback_function = [this](rs2::event_information& info){change_device_callback(info);};
+									_ctx.set_devices_changed_callback(change_device_callback_function);
+									StartDevice();
 								}
 								else
 								{

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -12,6 +12,9 @@
 #include <thread>
 #include <regex>
 
+#include <nodelet/NodeletUnload.h>
+
+
 using namespace realsense2_camera;
 
 #define REALSENSE_ROS_EMBEDDED_VERSION_STR (VAR_ARG_STRING(VERSION: REALSENSE_ROS_MAJOR_VERSION.REALSENSE_ROS_MINOR_VERSION.REALSENSE_ROS_PATCH_VERSION))
@@ -29,8 +32,9 @@ std::string api_version_to_string(int version)
 	return ss.str();
 }
 
-RealSenseNodeFactory::RealSenseNodeFactory():
-	_is_alive(true)
+RealSenseNodeFactory::RealSenseNodeFactory() :
+	_is_alive(true),
+	_initialized(false)
 {
 	rs2_error* e = nullptr;
 	std::string running_librealsense_version(api_version_to_string(rs2_get_api_version(&e)));
@@ -55,10 +59,26 @@ RealSenseNodeFactory::RealSenseNodeFactory():
 
 RealSenseNodeFactory::~RealSenseNodeFactory()
 {
-	_is_alive = false;
-	if (_query_thread.joinable())
+	try
 	{
-		_query_thread.join();
+		_initialized = false;
+		_data_monitor_timer.stop();
+		_is_alive = false;
+		if (_query_thread.joinable())
+		{
+			_query_thread.join();
+		}
+
+		_realSenseNode.reset();
+		if (_device)
+		{
+			_device.hardware_reset();
+			_device = rs2::device();
+		}
+	}
+	catch (const rs2::error& e)
+	{
+		ROS_ERROR_STREAM("Exception: " << e.what());
 	}
 }
 
@@ -208,29 +228,31 @@ void RealSenseNodeFactory::getDevice(rs2::device_list list)
 
 void RealSenseNodeFactory::change_device_callback(rs2::event_information& info)
 {
-	if (info.was_removed(_device))
+        // 20201103 @130s is afraid the behavior might have changed in https://github.com/plusone-robotics/realsense/pull/28
+        // Upstream may request maintaining backward compatiblity.
+	if (_initialized)
 	{
-		ROS_ERROR("The device has been disconnected!");
-		_realSenseNode.reset(nullptr);
-		_device = rs2::device();
-	}
-	if (!_device)
-	{
-		rs2::device_list new_devices = info.get_new_devices();
-		if (new_devices.size() > 0)
+		if (info.was_removed(_device))
 		{
-			ROS_INFO("Checking new devices...");
-			getDevice(new_devices);
-			if (_device)
-			{
-				StartDevice();
-			}
+			ROS_ERROR("The device has been disconnected!");
+			ROS_ERROR("Shutting down ...");
+			shutdown();
 		}
 	}
 }
 
 void RealSenseNodeFactory::onInit()
 {
+	auto nh = getNodeHandle();
+	auto privateNh = getPrivateNodeHandle();
+
+	privateNh.param("initial_reset", _initial_reset, false);
+	_init_timer = nh.createWallTimer(ros::WallDuration(1.0), &RealSenseNodeFactory::initialize, this, true);
+}
+
+void RealSenseNodeFactory::initialize(const ros::WallTimerEvent &ignored)
+{
+	_device = rs2::device();
 	try
 	{
 #ifdef BPDEBUG
@@ -244,40 +266,73 @@ void RealSenseNodeFactory::onInit()
     	privateNh.param("usb_port_id", _usb_port_id, std::string(""));
     	privateNh.param("device_type", _device_type, std::string(""));
 
+		std::string timeout_action;
+		privateNh.param("timeout_action", timeout_action, std::string("warn"));
+		if (timeout_action == "warn")
+		{
+			_timeout_action = TIMEOUT_WARN;
+		}
+		else if (timeout_action == "reset")
+		{
+			_timeout_action = TIMEOUT_RESET;
+		}
+		else if (timeout_action == "shutdown")
+		{
+			_timeout_action = TIMEOUT_SHUTDOWN;
+		}
+		else
+		{
+			_timeout_action = TIMEOUT_WARN;
+			ROS_WARN("Invalid timeout_action (warn|reset|shutdown): %s", timeout_action.c_str());
+		}
+
 		std::string rosbag_filename("");
 		privateNh.param("rosbag_filename", rosbag_filename, std::string(""));
 		if (!rosbag_filename.empty())
 		{
-			{
-				ROS_INFO_STREAM("publish topics from rosbag file: " << rosbag_filename.c_str());
-				auto pipe = std::make_shared<rs2::pipeline>();
-				rs2::config cfg;
-				cfg.enable_device_from_file(rosbag_filename.c_str(), false);
-				cfg.enable_all_streams();
-				pipe->start(cfg); //File will be opened in read mode at this point
-				_device = pipe->get_active_profile().get_device();
-				_serial_no = _device.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
-			}
-			if (_device)
-			{
-				StartDevice();
-			}
+			ROS_INFO_STREAM("publish topics from rosbag file: " << rosbag_filename.c_str());
+			auto pipe = std::make_shared<rs2::pipeline>();
+			rs2::config cfg;
+			cfg.enable_device_from_file(rosbag_filename.c_str(), false);
+			cfg.enable_all_streams();
+			pipe->start(cfg); //File will be opened in read mode at this point
+			_device = pipe->get_active_profile().get_device();
+			_realSenseNode = std::shared_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
+			_realSenseNode->publishTopics();
+			_realSenseNode->registerDynamicReconfigCb(nh);
 		}
 		else
 		{
-			privateNh.param("initial_reset", _initial_reset, false);
-
+			_is_alive = true;
 			_query_thread = std::thread([=]()
 						{
+							ROS_DEBUG("Waiting for device...");
+
+ 
 							std::chrono::milliseconds timespan(6000);
 							while (_is_alive && !_device)
 							{
-								getDevice(_ctx.query_devices());
+								ROS_DEBUG("Checking for device...");
+								_device = getDevice();
+ 								// getDevice(_ctx.query_devices());  // This line is obtained from the latest upstream.
 								if (_device)
 								{
-									std::function<void(rs2::event_information&)> change_device_callback_function = [this](rs2::event_information& info){change_device_callback(info);};
-									_ctx.set_devices_changed_callback(change_device_callback_function);
-									StartDevice();
+									ROS_DEBUG("got device");
+									if (_initial_reset)
+									{
+										ROS_DEBUG("Resetting device...");
+										_initial_reset = false;
+										_device.hardware_reset();
+										std::this_thread::sleep_for(std::chrono::seconds(10));
+										_device = getDevice();
+									}
+									if (_device)
+									{
+										ROS_DEBUG("starting device...");
+										std::function<void(rs2::event_information&)> change_device_callback_function = [this](rs2::event_information& info){change_device_callback(info);};
+										_ctx.set_devices_changed_callback(change_device_callback_function);
+										StartDevice();
+									}
 								}
 								else
 								{
@@ -285,6 +340,15 @@ void RealSenseNodeFactory::onInit()
 								}
 							}
 						});
+
+			if (!_shutdown_srv)
+			{
+				_shutdown_srv = privateNh.advertiseService("shutdown", &RealSenseNodeFactory::handleShutdown, this);
+			}
+			if (!_reset_srv)
+			{
+				_reset_srv = privateNh.advertiseService("reset", &RealSenseNodeFactory::handleReset, this);
+			}
 		}
 	}
 	catch(const std::exception& ex)
@@ -299,9 +363,55 @@ void RealSenseNodeFactory::onInit()
 	}
 }
 
+void RealSenseNodeFactory::dataMonitor(const ros::TimerEvent &e)
+{
+	if (!_realSenseNode || _data_timeout <= 0.0)
+	{
+		return;
+	}
+
+	ros::Time timeout = e.current_real - ros::Duration(_data_timeout);
+
+	std::vector<std::string> stale_topics;
+	if (!std::dynamic_pointer_cast<BaseRealSenseNode>(_realSenseNode)->checkTopics(timeout, stale_topics))
+	{
+		if (_timeout_action == TIMEOUT_WARN)
+		{
+			std::string stale_topic_string;
+			for (const auto& topic: stale_topics)
+			{
+				stale_topic_string += topic + ", ";
+			}
+			ROS_WARN_THROTTLE(1.0, "Realsense data timed out. Stale topics: %s", stale_topic_string.c_str());
+		}
+		else if (_timeout_action == TIMEOUT_RESET)
+		{
+			ROS_ERROR("Realsense data timed out. Resetting driver.");
+			ROS_ERROR("The following topics were stale:");
+			for (const auto& topic: stale_topics)
+			{
+				ROS_ERROR("  %s", topic.c_str());
+			}
+			reset();
+		}
+		else if (_timeout_action == TIMEOUT_SHUTDOWN)
+		{
+			ROS_ERROR("Realsense data timed out. Shutting down driver.");
+			ROS_ERROR("The following topics were stale:");
+			for (const auto& topic: stale_topics)
+			{
+				ROS_ERROR("  %s", topic.c_str());
+			}
+			shutdown();
+		}
+	}
+}
+
 void RealSenseNodeFactory::StartDevice()
 {
-	if (_realSenseNode) _realSenseNode.reset();
+	if (_realSenseNode) _realSenseNode.reset();  // This line is obtained from the latest upstream.
+	try
+	{
 	ros::NodeHandle nh = getNodeHandle();
 	ros::NodeHandle privateNh = getPrivateNodeHandle();
 	// TODO
@@ -328,10 +438,10 @@ void RealSenseNodeFactory::StartDevice()
 	case RS_USB2_PID:
 	case RS_L515_PID_PRE_PRQ:
 	case RS_L515_PID:
-		_realSenseNode = std::unique_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
+		_realSenseNode = std::shared_ptr<BaseRealSenseNode>(new BaseRealSenseNode(nh, privateNh, _device, _serial_no));
 		break;
 	case RS_T265_PID:
-		_realSenseNode = std::unique_ptr<T265RealsenseNode>(new T265RealsenseNode(nh, privateNh, _device, _serial_no));
+		_realSenseNode = std::shared_ptr<T265RealsenseNode>(new T265RealsenseNode(nh, privateNh, _device, _serial_no));
 		break;
 	default:
 		ROS_FATAL_STREAM("Unsupported device!" << " Product ID: 0x" << pid_str);
@@ -340,6 +450,97 @@ void RealSenseNodeFactory::StartDevice()
 	}
 	assert(_realSenseNode);
 	_realSenseNode->publishTopics();
+	_realSenseNode->registerDynamicReconfigCb(nh);
+
+	_initialized = true;
+
+	_data_timeout = privateNh.param("data_timeout", 0.0);
+	if (_data_timeout > 0.0)
+	{
+		ROS_INFO("starting data monitor ...");
+		_data_monitor_timer = nh.createTimer(ros::Duration(_data_timeout), &RealSenseNodeFactory::dataMonitor, this, false);
+	}
+	else
+	{
+		ROS_INFO("not monitoring data.");
+	}
+  }
+	catch (const rs2::error& e)
+	{
+		ROS_ERROR_STREAM("Exception: " << e.what());
+	}
+}
+
+bool RealSenseNodeFactory::shutdown()
+{
+	_initialized = false;
+	_data_monitor_timer.stop();
+
+	std::string manager_name = ros::this_node::getName();
+	std::string unload_service = manager_name + "/unload_nodelet";
+
+	if (ros::service::waitForService(unload_service, 0.1))
+	{
+		nodelet::NodeletUnload srv;
+		srv.request.name = getName();
+		if (!ros::service::call(unload_service, srv) || !srv.response.success)
+		{
+			ROS_WARN("Failed to unload nodelet, requesting shutdown ...");
+			ros::requestShutdown();
+		}
+	}
+	else
+	{
+		ROS_WARN("Failed to find unload nodelet service, requesting shutdown ...");
+		ros::requestShutdown();
+	}
+
+	return true;
+}
+
+bool RealSenseNodeFactory::reset()
+{
+	if (!_initialized)
+	{
+		return false;
+	}
+
+	_initialized = false;
+
+	_data_monitor_timer.stop();
+
+	_is_alive = false;
+	if (_query_thread.joinable())
+	{
+		_query_thread.join();
+	}
+
+	try
+	{
+	_realSenseNode.reset();
+		if (_device)
+		{
+			_device.hardware_reset();
+			_device = rs2::device();
+		}
+	}
+	catch (const rs2::error& e)
+	{
+		ROS_ERROR_STREAM("Exception: " << e.what());
+	}
+
+	_init_timer = getNodeHandle().createWallTimer(ros::WallDuration(1.0), &RealSenseNodeFactory::initialize, this, true);
+	return true;
+}
+
+bool RealSenseNodeFactory::handleShutdown(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response)
+{
+	return shutdown();
+}
+
+bool RealSenseNodeFactory::handleReset(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response)
+{
+	return reset();
 }
 
 void RealSenseNodeFactory::tryGetLogSeverity(rs2_log_severity& severity) const


### PR DESCRIPTION
This is a cherry-pick of the changes that was merged in at https://github.com/plusone-robotics/realsense/pull/28 into an older development branch on this fork.

## Branch
- Base: [por_development_202010](https://github.com/plusone-robotics/realsense/compare/por_development_202010), which is a new branch that was checked out from the `tag` [2.2.17](https://github.com/IntelRealSense/realsense-ros/releases/tag/2.2.17).
- Target: `por_development_202010`

## Review items includes:
1. Dev-test. This will likely be done on a in-house, integrated application.
   - [ ] Realsense ROS node starts.
   - [ ] Re-spawning functionality that was added in https://github.com/plusone-robotics/realsense/pull/28 works.
   - Else?
1. Code review
   - [ ] Whether newer changes in the upstream repo's [development](https://github.com/IntelRealSense/realsense-ros/tree/development) is not removed unintentionally.

## TODOs post-merge
1. [ ] Tag on plusone-robotics' fork.
1. [ ] PR to the Intel's upstream.
