### PR TITLE
Enable infrared RGB from launch file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ Setting *unite_imu_method* creates a new topic, *imu*, that replaces the default
 - **publish_tf**: boolean, publish or not TF at all. Defaults to True.
 - **tf_publish_rate**: double, positive values mean dynamic transform publication with specified rate, all other values mean static transform publication. Defaults to 0 
 - **publish_odom_tf**: If True (default) publish TF from odom_frame to pose_frame.
+- **infrargb**: When set to True (default: False), it configures the infrared camera to stream in RGB (color) mode, thus enabling the use of a RGB image in the same frame as the depth image, potentially avoiding frame transformation related errors. When this feature is required, you are additionally required to also enable `enable_infra:=true` for the infrared stream to be enabled.
+  - **NOTE** The configuration required for `enable_infra` is independent of `enable_depth`
+  - **NOTE** To enable the Infrared stream, you should enable `enable_infra:=true` NOT `enable_infra1:=true` nor `enable_infra2:=true`
+  - **NOTE** This feature is only supported by Realsense sensors with RGB streams available from the `infra` cameras, which can be checked by observing the output of `rs-enumerate-devices`
 
 
 ### RGBD Point Cloud

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -24,6 +24,7 @@
   <arg name="enable_infra"        default="false"/>
   <arg name="enable_infra1"       default="false"/>
   <arg name="enable_infra2"       default="false"/>
+  <arg name="enable_infrargb"    default="false"/>
 
   <arg name="color_width"         default="640"/>
   <arg name="color_height"        default="480"/>
@@ -125,6 +126,7 @@
     <param name="enable_infra"             type="bool" value="$(arg enable_infra)"/>
     <param name="enable_infra1"            type="bool" value="$(arg enable_infra1)"/>
     <param name="enable_infra2"            type="bool" value="$(arg enable_infra2)"/>
+    <param name="infrargb"                 type="bool" value="$(arg enable_infrargb)"/>
 
     <param name="fisheye_fps"              type="int"  value="$(arg fisheye_fps)"/>
     <param name="depth_fps"                type="int"  value="$(arg depth_fps)"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -21,6 +21,7 @@
   <arg name="enable_infra"        default="false"/>
   <arg name="enable_infra1"       default="false"/>
   <arg name="enable_infra2"       default="false"/>
+  <arg name="enable_infrargb"    default="false"/>
 
   <arg name="color_width"         default="640"/>
   <arg name="color_height"        default="480"/>
@@ -88,6 +89,7 @@
       <arg name="enable_infra"            value="$(arg enable_infra)"/>
       <arg name="enable_infra1"            value="$(arg enable_infra1)"/>
       <arg name="enable_infra2"            value="$(arg enable_infra2)"/>
+      <arg name="enable_infrargb"         value="$(arg enable_infrargb)"/>
 
       <arg name="fisheye_fps"              value="$(arg fisheye_fps)"/>
       <arg name="depth_fps"                value="$(arg depth_fps)"/>


### PR DESCRIPTION
# Problem

Infrared-RGB functionality https://github.com/plusone-robotics/realsense/pull/30 adds a ROS Parameter to enable itself, which is not available yet in the launch files in `realsense2_camera` pkg. Users have to define such a Parameter by themselves.

# Approach

Add needed ROS Parameters.

# Test

With `roslaunch realsense2_camera rs_camera.launch enable_infra:=true enable_infra_rgb:=true`, I was able to see `/camera/infra/image_raw` topic being published (without the change in this PR and the command args I didn't see it published).

![Screenshot from 2020-11-06 14-47-31](https://user-images.githubusercontent.com/1840401/98409606-2d4e4780-2041-11eb-9f60-38cbf7c7c6c8.png)

FYI I used the following docker-compose config file and have Realsense driver running in the Docker container. Worked.

```
version: '2.3'
services:
  realsense:
      image: %REPLACE_WITH_YOUR_IMG%
      container_name: realsense_launch
      restart: "no"
      network_mode: "host"
      privileged: true
      volumes:
        - /dev:/dev
      command: /bin/bash -c "source /opt/por/setup.bash && roslaunch realsense2_camera rs_camera.launch enable_infra:=true enable_infra_rgb:=true"
```
