### PR TITLE
Event based reset

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(realsense2_camera)
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 option(BUILD_WITH_OPENMP "Use OpenMP" OFF)
 option(SET_USER_BREAK_AT_STARTUP "Set user wait point in startup (for debug)" OFF)
@@ -62,7 +62,7 @@ endif()
 
 if (WIN32)
 else()
-set(CMAKE_CXX_FLAGS "-fPIE -fPIC -std=c++11 -D_FORTIFY_SOURCE=2 -fstack-protector -Wformat -Wformat-security -Wall ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-fPIE -fPIC -std=c++17 -D_FORTIFY_SOURCE=2 -fstack-protector -Wformat -Wformat-security -Wall ${CMAKE_CXX_FLAGS}")
 endif()
 
 add_message_files(
@@ -128,7 +128,7 @@ target_link_libraries(${PROJECT_NAME}
 if(WIN32)
 set_target_properties(${realsense2_LIBRARY} PROPERTIES MAP_IMPORTED_CONFIG_RELWITHDEBINFO RELEASE)
 target_link_libraries(${PROJECT_NAME}
-    realsense2::realsense2 
+    realsense2::realsense2
     realsense2::realsense-file
     )
 endif()
@@ -160,4 +160,3 @@ install(DIRECTORY rviz/
 install(FILES nodelet_plugins.xml
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
     )
-

--- a/realsense2_camera/include/realsense2_camera/constants.h
+++ b/realsense2_camera/include/realsense2_camera/constants.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+#include <chrono>
 
 #define REALSENSE_ROS_MAJOR_VERSION    2
 #define REALSENSE_ROS_MINOR_VERSION    3
@@ -36,11 +37,11 @@ namespace realsense2_camera
     const uint16_t RS416_RGB_PID    = 0x0B52; // F416 RGB
     const uint16_t RS405_PID        = 0x0b0c; // DS5U
     const uint16_t RS455_PID        = 0x0B5C; // D455
-    const uint16_t RS_T265_PID      = 0x0b37; // 
-    const uint16_t RS_L515_PID_PRE_PRQ = 0x0B3D; // 
-    const uint16_t RS_L515_PID      = 0x0B64; // 
+    const uint16_t RS_T265_PID      = 0x0b37; //
+    const uint16_t RS_L515_PID_PRE_PRQ = 0x0B3D; //
+    const uint16_t RS_L515_PID      = 0x0B64; //
     const uint16_t RS_L535_PID      = 0x0b68;
-    
+
 
     const bool ALIGN_DEPTH             = false;
     const bool POINTCLOUD              = false;
@@ -117,4 +118,7 @@ namespace realsense2_camera
                                                           FISHEYE1, FISHEYE2, CONFIDENCE};
 
     const std::vector<stream_index_pair> HID_STREAMS = {GYRO, ACCEL, POSE};
+
+    const std::chrono::duration<double> MAX_RESET_WAIT(10); // Max wait for reset event to complete in seconds
+    const std::chrono::seconds RESET_SLEEP_INTERVAL(1); // Sleep interval during reset check
 }  // namespace realsense2_camera

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -221,10 +221,12 @@ void RealSenseNodeFactory::getDevice(rs2::device_list list)
 
             ROS_INFO("Resetting device...");
             _device.hardware_reset();
-            while(!reset_complete)
+            auto start_time = std::chrono::steady_clock::now();
+            while(!reset_complete && std::chrono::steady_clock::now() - start_time < MAX_RESET_WAIT)
             {
-                ros::Duration(0.1).sleep();
+                std::this_thread::sleep_for(RESET_SLEEP_INTERVAL);
             }
+            ROS_INFO(reset_complete ? "Reset complete" : "Timed out waiting on reset event. Starting camera...");
             _device = rs2::device();
         }
         catch(const std::exception& ex)

--- a/realsense2_camera/src/realsense_node_factory.cpp
+++ b/realsense2_camera/src/realsense_node_factory.cpp
@@ -132,7 +132,7 @@ void RealSenseNodeFactory::getDevice(rs2::device_list list)
 				}
 				else
 				{
-					ROS_INFO_STREAM("Device with port number " << port_id << " was found.");					
+					ROS_INFO_STREAM("Device with port number " << port_id << " was found.");
 				}
 				bool found_device_type(true);
 				if (!_device_type.empty())
@@ -201,20 +201,37 @@ void RealSenseNodeFactory::getDevice(rs2::device_list list)
 		_ctx.unload_tracking_module();
 	}
 
-	if (_device && _initial_reset)
-	{
-		_initial_reset = false;
-		try
-		{
-			ROS_INFO("Resetting device...");
-			_device.hardware_reset();
-			_device = rs2::device();
-		}
-		catch(const std::exception& ex)
-		{
-			ROS_WARN_STREAM("An exception has been thrown: " << ex.what());
-		}
-	}
+    if (_device && _initial_reset)
+    {
+        _initial_reset = false;
+        bool reset_complete(false);
+        try
+        {
+            rs2::context contex;
+            contex.set_devices_changed_callback([&](rs2::event_information& info)
+            {
+            // loop through all new devices
+            for (auto&& dev : info.get_new_devices())
+            {
+                auto dev_serial_no = dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+                reset_complete = dev_serial_no == _serial_no;
+            }
+            });
+
+
+            ROS_INFO("Resetting device...");
+            _device.hardware_reset();
+            while(!reset_complete)
+            {
+                ros::Duration(0.1).sleep();
+            }
+            _device = rs2::device();
+        }
+        catch(const std::exception& ex)
+        {
+            ROS_WARN_STREAM("An exception has been thrown: " << ex.what());
+        }
+    }
 }
 
 void RealSenseNodeFactory::change_device_callback(rs2::event_information& info)


### PR DESCRIPTION
* Change compile flags to c++17 since we use the same to build the SDK (librealsense2).
* Add event based check to ensure the device completes reset prior to starting pipeline